### PR TITLE
Redesign of create_input_tables function

### DIFF
--- a/R/create_input_tables.R
+++ b/R/create_input_tables.R
@@ -23,6 +23,8 @@
 # folder_out = "."
 # input = c("oxygen/initial_conditions",
 #           "phytoplankton/growth/maximum_growth_rates")
+# models_coupled = c("GLM-AED2", "GOTM-Selmaprotbas", "GOTM-WET", 
+#                    "Simstrat-AED2", "MyLake", "PCLake")
 
 create_input_tables <- function(folder = ".", config_file, folder_out = folder, input = NULL,
                                 models_coupled = c("GLM-AED2", "GOTM-Selmaprotbas", "GOTM-WET", 
@@ -88,6 +90,9 @@ create_input_tables <- function(folder = ".", config_file, folder_out = folder, 
   }
   
   input_table <- input_table[input_table$include,]
+  
+  # Only the models specified by the user input
+  input_table <- input_table[input_table$model_coupled %in% models_coupled,]
   
   # Add a "value" column to the input table. Users can enter their values here
   if(nrow(input_table) > 0){

--- a/man/create_input_tables.Rd
+++ b/man/create_input_tables.Rd
@@ -8,12 +8,9 @@ create_input_tables(
   folder = ".",
   config_file,
   folder_out = folder,
-  modules = "all",
-  processes = "all",
-  subprocesses = "all",
+  input = NULL,
   models_coupled = c("GLM-AED2", "GOTM-Selmaprotbas", "GOTM-WET", "Simstrat-AED2",
-    "MyLake", "PCLake"),
-  parameters = "all"
+    "MyLake", "PCLake")
 )
 }
 \arguments{
@@ -23,20 +20,12 @@ create_input_tables(
 
 \item{folder_out}{path; in what folder should the files be placed}
 
-\item{modules}{character; "all" to include everything, vector otherwise}
-
-\item{processes}{character; "all" to include everything, vector otherwise}
-
-\item{subprocesses}{character; "all" to include everything, vector otherwise}
-
-\item{models_coupled}{character; options "GLM-AED2", "GOTM-Selmaprotbas", "GOTM-WET",
-"Simstrat-AED2", "MyLake", "PCLake"}
-
-\item{parameters}{character; "all" to include everything, vector otherwise}
+\item{input}{character vector; for what parameters do you want to fill in values}
 }
 \description{
 Create csv files from the LakeEnsemblR dictionary file, where the user can enter values 
-for selected parameters. Running the function with default arguments will give all parameters.
+for selected parameters. Running the function with default arguments will print all
+empty input files, whereas adding the argument "all" will print all parameters.
 }
 \examples{
 


### PR DESCRIPTION
The create_input_tables function will now always generate input files for all modules. By default they will be empty, and the users can specify for what parameters they want to provide values. This can be general, e.g. the whole oxygen module, or specific, e.g. only a certain subprocess. 